### PR TITLE
Add KitKat support

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="fr.slvn.appops"
-    android:versionCode="3"
-    android:versionName="1.2" >
+    android:versionCode="4"
+    android:versionName="1.3" >
 
     <uses-sdk
         android:minSdkVersion="18"
-        android:targetSdkVersion="18"
-        android:maxSdkVersion="18"/>
+        android:targetSdkVersion="19"
+        android:maxSdkVersion="19"/>
 
     <application
         android:icon="@mipmap/ic_launcher_settings"

--- a/src/main/java/fr/slvn/appops/MainActivity.java
+++ b/src/main/java/fr/slvn/appops/MainActivity.java
@@ -17,7 +17,13 @@ public class MainActivity extends Activity {
 
     private void launchAppOps() {
         try {
-            Intent intent = new Intent("android.settings.APP_OPS_SETTINGS");
+            Intent intent = new Intent();
+            intent.setClassName("com.android.settings", "com.android.settings.Settings");
+            intent.setAction(Intent.ACTION_MAIN);
+            intent.addCategory(Intent.CATEGORY_DEFAULT);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
+            intent.putExtra(":android:show_fragment", "com.android.settings.applications.AppOpsSummary");
+
             startActivity(intent);
         } catch (Exception e) {
             Toast.makeText(this, R.string.error_msg, Toast.LENGTH_LONG).show();


### PR DESCRIPTION
Hello Sylvain,

There are so many apps in the PlayStore  doing the same thing BUT asking for many permissions, so this is why I was using yours (power of open source).
I added the KitKat support (from this source : http://brightechno.com/blog/archives/211). I tested it using my Nexus 4 on KitKat and tested also the fix on 4.3 emulator.
Could you please update the app on PlayStore ?

Thanks.
Rémi
